### PR TITLE
fixforcrash

### DIFF
--- a/LiteDB/Engine/Engine/Transaction.cs
+++ b/LiteDB/Engine/Engine/Transaction.cs
@@ -84,13 +84,15 @@ namespace LiteDB.Engine
 
                 return result;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 LOG(ex.Message, "ERROR");
 
-                transaction.Rollback();
-
-                _monitor.ReleaseTransaction(transaction);
+                if (transaction.State != TransactionState.Disposed) //This will happen if fails in this.CommitAndReleaseTransaction. We won't rollback in this case since transaction already is done 
+                {
+                    transaction.Rollback();
+                    _monitor.ReleaseTransaction(transaction);
+                }
 
                 throw;
             }

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <AssemblyVersion>5.0.10</AssemblyVersion>
-    <FileVersion>5.0.10</FileVersion>
-    <VersionPrefix>5.0.10</VersionPrefix>
+    <AssemblyVersion>5.0.10.2</AssemblyVersion>
+    <FileVersion>5.0.10.2</FileVersion>
+    <VersionPrefix>5.0.10.2</VersionPrefix>
     <Authors>Maurício David</Authors>
     <Product>LiteDB</Product>
     <Description>Fork of LiteDB - A lightweight embedded .NET NoSQL document store in a single datafile</Description>
@@ -12,7 +12,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Title>LiteDB</Title>
     <PackageId>StrangeLoopGames.LiteDB</PackageId>
-    <PackageVersion>5.0.10</PackageVersion>
+    <PackageVersion>5.0.10.2</PackageVersion>
     <PackageTags>database nosql embedded</PackageTags>
     <PackageIcon>icon_64x64.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -30,7 +30,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Strange Loop Games</Company>
-    <Version>5.0.10</Version>
+    <Version>5.0.10.2</Version>
   </PropertyGroup>
   
   <!--


### PR DESCRIPTION
it fixes this crash https://app.clickup.com/t/10591183/ECO-17767 .
There are two problems in log.
1) For some unknown reason it fails to make a transaction after this transaction is disposed
2) Instead of throwing an exception, it fails at rollback, and exception is overwroted  with message "Can't rollback disposed transaction".
3) After failing in rollback db becomes corrupted

This PR fixes 2 (now it will show proper message of exception) and may fix 3 (but it depends on how exactly it fails at 1)